### PR TITLE
Add downloaded image to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wss-wu-dryville.jpg


### PR DESCRIPTION
Per #16, I added a downloaded image (wss-wu-dryville.jpg) to the .gitignore file :cactus::house: